### PR TITLE
Add structure helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+<!-- README.md -->
+<!-- Overview of the full stack template. -->
+<!-- Explains the directory layout and setup. -->
+
+# AI SaaS Template
+
+This repository contains a minimal full stack template. It aims to stay small and easy to read. The code is kept simple on purpose.
+
+## Tech Stack
+
+- **Frontend**: Next.js with TypeScript and Lucide React icons.
+- **Backend**: Python FastAPI.
+- **Database**: Supabase.
+- **Auth**: not configured.
+- **Payments**: not configured.
+- **Hosting**: run locally or deploy as you prefer.
+- **CI/CD**: none included.
+
+## Structure
+
+```
+frontend/    Next.js project
+backend/     FastAPI server code
+README.md    Overview and instructions
+agents.md    Contributor guidelines
+```
+
+You can start the frontend with `npm install && npm run dev` inside the `frontend` folder. The backend runs with `pip install -r requirements.txt` and `uvicorn backend.main:app`.
+
+## Project tree
+
+If the `tree` command is missing, run the helper script:
+
+```bash
+python3 show_structure.py
+```
+
+This prints the directory layout up to three levels deep.
+
+## Troubleshooting
+
+`npm install lucide-react` may fail in restricted environments. Ensure your machine can reach the npm registry.
+
+`brew install tree` or `apt-get install tree` might fail if those package managers are unavailable. Use the `show_structure.py` script instead.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,23 @@
+# backend/main.py
+# Starts a FastAPI server with a simple healthcheck route.
+# Does not contain business logic; only demo endpoints.
+
+from fastapi import FastAPI
+from supabase import create_client, Client
+import os
+
+app = FastAPI()
+
+# create Supabase client using env vars
+SUPABASE_URL = os.getenv('SUPABASE_URL', '')
+SUPABASE_KEY = os.getenv('SUPABASE_KEY', '')
+
+def get_client() -> Client:
+    """Return an authenticated Supabase client."""
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+@app.get("/health")
+def health():
+    """Simple healthcheck endpoint."""
+    return {"status": "ok"}
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.2
+uvicorn==0.29.0
+supabase==1.0.3

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -1,0 +1,12 @@
+# backend/supabase_client.py
+# Provides a helper to create the Supabase client.
+# No direct DB operations are implemented here.
+
+from supabase import create_client, Client
+import os
+
+def create_supabase_client() -> Client:
+    """Return an authenticated Supabase client."""
+    url = os.getenv('SUPABASE_URL', '')
+    key = os.getenv('SUPABASE_KEY', '')
+    return create_client(url, key)

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ai-saas-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "lucide-react": "latest"
+  },
+  "devDependencies": {}
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,17 @@
+// frontend/pages/index.tsx
+// Home page for the Next.js app.
+// Presents a simple UI example using a Lucide React icon.
+
+import { FC } from 'react';
+import { Rocket } from 'lucide-react';
+
+const Home: FC = () => {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+      <h1>Welcome to the AI SaaS Template</h1>
+      <Rocket color="blue" size={48} />
+    </div>
+  );
+};
+
+export default Home;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/show_structure.py
+++ b/show_structure.py
@@ -1,0 +1,35 @@
+# show_structure.py
+# Prints a simple directory tree up to depth 3.
+# Used when the `tree` command is unavailable.
+
+import os
+
+MAX_DEPTH = 3
+
+
+def walk(dir_path: str, prefix: str = "", depth: int = 0) -> None:
+    """Recursively print entries up to MAX_DEPTH."""
+    if depth > MAX_DEPTH:
+        return
+    try:
+        entries = sorted(os.listdir(dir_path))
+    except FileNotFoundError:
+        return
+
+    for idx, entry in enumerate(entries):
+        path = os.path.join(dir_path, entry)
+        connector = "└── " if idx == len(entries) - 1 else "├── "
+        print(prefix + connector + entry)
+        if os.path.isdir(path):
+            extension = "    " if idx == len(entries) - 1 else "│   "
+            walk(path, prefix + extension, depth + 1)
+
+
+def main() -> None:
+    root = os.path.dirname(os.path.abspath(__file__))
+    print(os.path.basename(root))
+    walk(root)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add small Python helper to print directory tree when `tree` is unavailable
- document the helper script and mention failure cases

## Testing
- `python3 -m py_compile backend/main.py backend/supabase_client.py show_structure.py`
- `npm install lucide-react` *(fails: 403 Forbidden)*
- `brew install tree` *(fails: command not found)*
- `apt-get install -y tree` *(fails: unable to locate package)*
- `python3 show_structure.py | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_68433336ee4083209f015550245e80c1